### PR TITLE
Implement NTP server and key config options

### DIFF
--- a/config/main.py
+++ b/config/main.py
@@ -6943,56 +6943,161 @@ def ntp(ctx):
     config_db.connect()
     ctx.obj = {'db': config_db}
 
-@ntp.command('add')
-@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
-@click.pass_context
-def add_ntp_server(ctx, ntp_ip_address):
-    """ Add NTP server IP """
-    if ADHOC_VALIDATION:
-        if not clicommon.is_ipaddress(ntp_ip_address):
-            ctx.fail('Invalid IP address')
-    db = ValidatedConfigDBConnector(ctx.obj['db'])
-    ntp_servers = db.get_table("NTP_SERVER")
-    if ntp_ip_address in ntp_servers:
-        click.echo("NTP server {} is already configured".format(ntp_ip_address))
-        return
-    else:
-        try:
-            db.set_entry('NTP_SERVER', ntp_ip_address,
-                         {'resolve_as': ntp_ip_address,
-                          'association_type': 'server'})
-        except ValueError as e:
-            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
-        click.echo("NTP server {} added to configuration".format(ntp_ip_address))
-        try:
-            click.echo("Restarting ntp-config service...")
-            clicommon.run_command(['systemctl', 'restart', 'ntp-config'], display_cmd=False)
-        except SystemExit as e:
-            ctx.fail("Restart service ntp-config failed with error {}".format(e))
-
-@ntp.command('del')
-@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
-@click.pass_context
-def del_ntp_server(ctx, ntp_ip_address):
-    """ Delete NTP server IP """
-    if ADHOC_VALIDATION:
-        if not clicommon.is_ipaddress(ntp_ip_address):
-            ctx.fail('Invalid IP address')
-    db = ValidatedConfigDBConnector(ctx.obj['db'])
-    ntp_servers = db.get_table("NTP_SERVER")
-    if ntp_ip_address in ntp_servers:
-        try:
-            db.set_entry('NTP_SERVER', '{}'.format(ntp_ip_address), None)
-        except JsonPatchConflict as e:
-            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
-        click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
-    else:
-        ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))
+def _restart_ntp_service(ctx):
     try:
         click.echo("Restarting ntp-config service...")
         clicommon.run_command(['systemctl', 'restart', 'ntp-config'], display_cmd=False)
     except SystemExit as e:
         ctx.fail("Restart service ntp-config failed with error {}".format(e))
+
+
+def _add_ntp_server(ctx, ntp_ip_address, association_type, key_id, version):
+    if ADHOC_VALIDATION and clicommon.is_ipaddress(ntp_ip_address) is False:
+        ctx.fail('Invalid IP address')
+
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        click.echo("NTP server {} is already configured".format(ntp_ip_address))
+        return
+
+    entry = {
+        'resolve_as': ntp_ip_address,
+        'association_type': association_type
+    }
+    if key_id:
+        entry['key_id'] = str(key_id)
+    if version:
+        entry['version'] = str(version)
+
+    try:
+        db.set_entry('NTP_SERVER', ntp_ip_address, entry)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+    click.echo("NTP server {} added to configuration".format(ntp_ip_address))
+    _restart_ntp_service(ctx)
+
+
+@ntp.group('server')
+@click.pass_context
+def ntp_server(ctx):
+    """NTP server configuration"""
+    pass
+
+
+@ntp.command('add')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.option('--type', 'association_type', type=click.Choice(['server', 'peer']), default='server')
+@click.option('--key', 'key_id')
+@click.option('--version', type=int, default=4)
+@click.pass_context
+def add_ntp_server(ctx, ntp_ip_address, association_type, key_id, version):
+    """Add NTP server"""
+    _add_ntp_server(ctx, ntp_ip_address, association_type, key_id, version)
+
+
+@ntp_server.command('add')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.option('--type', 'association_type', type=click.Choice(['server', 'peer']), default='server')
+@click.option('--key', 'key_id')
+@click.option('--version', type=int, default=4)
+@click.pass_context
+def add_ntp_server_new(ctx, ntp_ip_address, association_type, key_id, version):
+    """Add NTP server"""
+    _add_ntp_server(ctx, ntp_ip_address, association_type, key_id, version)
+
+def _del_ntp_server(ctx, ntp_ip_address):
+    if ADHOC_VALIDATION and clicommon.is_ipaddress(ntp_ip_address) is False:
+        ctx.fail('Invalid IP address')
+
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    ntp_servers = db.get_table("NTP_SERVER")
+    if ntp_ip_address in ntp_servers:
+        try:
+            db.set_entry('NTP_SERVER', ntp_ip_address, None)
+        except JsonPatchConflict as e:
+            ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+        click.echo("NTP server {} removed from configuration".format(ntp_ip_address))
+    else:
+        ctx.fail("NTP server {} is not configured.".format(ntp_ip_address))
+
+    _restart_ntp_service(ctx)
+
+
+@ntp.command('del')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def del_ntp_server(ctx, ntp_ip_address):
+    """Delete NTP server"""
+    _del_ntp_server(ctx, ntp_ip_address)
+
+
+@ntp_server.command('del')
+@click.argument('ntp_ip_address', metavar='<ntp_ip_address>', required=True)
+@click.pass_context
+def del_ntp_server_new(ctx, ntp_ip_address):
+    """Delete NTP server"""
+    _del_ntp_server(ctx, ntp_ip_address)
+
+
+@ntp.group('key')
+@click.pass_context
+def ntp_key(ctx):
+    """NTP authentication key configuration"""
+    pass
+
+
+def _add_ntp_key(ctx, key_id, key, key_type, trusted):
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    keys = db.get_table('NTP_AUTH')
+    if key_id in keys:
+        ctx.fail(f"NTP key {key_id} already exists")
+
+    entry = {'secret': key, 'type': key_type}
+    entry['trusted'] = 'true' if trusted == 'yes' else 'false'
+
+    try:
+        db.set_entry('NTP_AUTH', key_id, entry)
+    except ValueError as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+    click.echo(f"NTP key {key_id} added")
+    _restart_ntp_service(ctx)
+
+
+def _del_ntp_key(ctx, key_id):
+    db = ValidatedConfigDBConnector(ctx.obj['db'])
+    keys = db.get_table('NTP_AUTH')
+    if key_id not in keys:
+        ctx.fail(f"NTP key {key_id} is not configured.")
+
+    try:
+        db.set_entry('NTP_AUTH', key_id, None)
+    except JsonPatchConflict as e:
+        ctx.fail("Invalid ConfigDB. Error: {}".format(e))
+
+    click.echo(f"NTP key {key_id} removed")
+    _restart_ntp_service(ctx)
+
+
+@ntp_key.command('add')
+@click.argument('key_id', metavar='<key_id>', required=True)
+@click.argument('key', metavar='<key>', required=True)
+@click.option('--type', 'key_type', type=click.Choice(['md5', 'sha1']), required=True)
+@click.option('--trusted', type=click.Choice(['yes', 'no']), default='no')
+@click.pass_context
+def add_ntp_key(ctx, key_id, key, key_type, trusted):
+    """Add NTP authentication key"""
+    _add_ntp_key(ctx, key_id, key, key_type, trusted)
+
+
+@ntp_key.command('del')
+@click.argument('key_id', metavar='<key_id>', required=True)
+@click.pass_context
+def del_ntp_key(ctx, key_id):
+    """Delete NTP authentication key"""
+    _del_ntp_key(ctx, key_id)
 
 #
 # 'sflow' group ('config sflow ...')

--- a/doc/Command-Reference.md
+++ b/doc/Command-Reference.md
@@ -9064,35 +9064,67 @@ This command displays a list of NTP peers known to the server as well as a summa
 
 This sub-section of commands is used to add or remove the configured NTP servers.
 
-**config ntp add**
+**config ntp server add**
 
-This command is used to add a NTP server IP address to the NTP server list.  Note that more that one NTP server IP address can be added in the device.
+Add a NTP server or peer to the configuration.
 
 - Usage:
   ```
-  config ntp add <ip_address>
+  config ntp server add <server> [--type <server|peer>] [--key <key_id>] [--version <ver>]
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo config ntp add 9.9.9.9
+  admin@sonic:~$ sudo config ntp server add 9.9.9.9 --type server --version 4
   NTP server 9.9.9.9 added to configuration
   Restarting ntp-config service...
   ```
 
-**config ntp delete**
+**config ntp server del**
 
-This command is used to delete a configured NTP server IP address.
+Delete a configured NTP server.
 
 - Usage:
   ```
-  config ntp del <ip_address>
+  config ntp server del <server>
   ```
 
 - Example:
   ```
-  admin@sonic:~$ sudo config ntp del 9.9.9.9
+  admin@sonic:~$ sudo config ntp server del 9.9.9.9
   NTP server 9.9.9.9 removed from configuration
+  Restarting ntp-config service...
+  ```
+
+**config ntp key add**
+
+Configure an authentication key used by NTP.
+
+- Usage:
+  ```
+  config ntp key add <key_id> <key> --type <md5|sha1> [--trusted yes|no]
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ntp key add 42 theanswer --type sha1 --trusted yes
+  NTP key 42 added
+  Restarting ntp-config service...
+  ```
+
+**config ntp key del**
+
+Delete a configured NTP authentication key.
+
+- Usage:
+  ```
+  config ntp key del <key_id>
+  ```
+
+- Example:
+  ```
+  admin@sonic:~$ sudo config ntp key del 42
+  NTP key 42 removed
   Restarting ntp-config service...
   ```
 

--- a/tests/ntp_test.py
+++ b/tests/ntp_test.py
@@ -1,0 +1,55 @@
+import os
+from click.testing import CliRunner
+from mock import patch
+
+import config.main as config
+from utilities_common.db import Db
+
+class TestNtp(object):
+    @classmethod
+    def setup_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = '1'
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ['UTILITIES_UNIT_TESTING'] = '0'
+
+    @patch('config.main.clicommon.run_command')
+    def test_ntp_server_add_del(self, mock_run):
+        mock_run.return_value = ("", 0)
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['ntp'].commands['server'].commands['add'],
+                               ['0.pool.ntp.org', '--type', 'server', '--key', '42', '--version', '4'],
+                               obj=obj)
+        assert result.exit_code == 0
+        entry = db.cfgdb.get_entry('NTP_SERVER', '0.pool.ntp.org')
+        assert entry == {'resolve_as': '0.pool.ntp.org', 'association_type': 'server', 'key_id': '42', 'version': '4'}
+        mock_run.assert_called_with(['systemctl', 'restart', 'ntp-config'], display_cmd=False)
+
+        result = runner.invoke(config.config.commands['ntp'].commands['server'].commands['del'],
+                               ['0.pool.ntp.org'], obj=obj)
+        assert result.exit_code == 0
+        table = db.cfgdb.get_table('NTP_SERVER')
+        assert '0.pool.ntp.org' not in table
+
+    @patch('config.main.clicommon.run_command')
+    def test_ntp_key_add_del(self, mock_run):
+        mock_run.return_value = ("", 0)
+        runner = CliRunner()
+        db = Db()
+        obj = {'db': db.cfgdb}
+
+        result = runner.invoke(config.config.commands['ntp'].commands['key'].commands['add'],
+                               ['42', 'theanswer', '--type', 'sha1', '--trusted', 'yes'], obj=obj)
+        assert result.exit_code == 0
+        entry = db.cfgdb.get_entry('NTP_AUTH', '42')
+        assert entry == {'secret': 'theanswer', 'type': 'sha1', 'trusted': 'true'}
+
+        result = runner.invoke(config.config.commands['ntp'].commands['key'].commands['del'],
+                               ['42'], obj=obj)
+        assert result.exit_code == 0
+        table = db.cfgdb.get_table('NTP_AUTH')
+        assert '42' not in table


### PR DESCRIPTION
## Summary
- support adding NTP servers with association type, version and key
- add commands to manage NTP authentication keys
- document new commands
- regression tests for new CLI logic

## Testing
- `python3 -m py_compile config/main.py tests/ntp_test.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sonic_py_common')*

------
https://chatgpt.com/codex/tasks/task_e_68428a0b4a90833099acf823f0746daf